### PR TITLE
add command to make /tmp/artifacts directory when exporting tagged image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       timeout-minutes: 4
       run: |
+        mkdir -p /tmp/artifacts
         docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-container.outputs.version }} > /tmp/artifacts/image.tar.gz
     - name: Anti Virus Scan
       timeout-minutes: 10


### PR DESCRIPTION
What
---
Fixes workflow step on the virus scan job. Previously workflow would attempt to export to folder that doesn't exist when running on the main branch. Fixes #119 