### PR TITLE
drop unsupported version of kubernetes older than a year

### DIFF
--- a/.github/workflows/helm-qa.yml
+++ b/.github/workflows/helm-qa.yml
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.20.15 
           - v1.21.9
           - v1.22.6
           - v1.23.3
@@ -70,7 +69,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.20.7
           - v1.21.2
           - v1.22.5
           - v1.23.3


### PR DESCRIPTION
Drops kube 1.20 support as it's no longer supported, leaves 1.21 1.22 and 1.23